### PR TITLE
Render context and window user data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 #ignore the intermediate object files in the hidden .build directory
 .build/*
+
+#ignore any 'test' files I create for prototyping
+test.*

--- a/Windows-Platform-Layer.jai
+++ b/Windows-Platform-Layer.jai
@@ -4,25 +4,13 @@
 // Keyboard input is tied to the operating system as well.
 // Thus Image/Framebuffer and User Input types are added to this file.
 
+// Bookmarked but pertinent to these data structures: 
+// https://stackoverflow.com/questions/15194002/why-does-opengl-be-designed-as-a-state-machine-originally 
+
 Pixel :: struct {
 	// assumes simple RGBA format where each value is a byte
 	blue, green, red, alpha: u8;
 }
-
-// it's almost like using toggles
-// so in the D3D way you would have something like the object passed in and you set that state
-// i think this is what I am getting hung up on is how do you talk back and forth between these things
-
-// what Nicol is saying is that you could have a 'render-command' and that is what i am trying to do 
-// but then you have all these disparate object all over the place
-// the rendering call would literally look something like
-// render :: ( Shader1, shader2, texture1, texture2, texture..n, vertex data, framebuffer, viewport setting and blend settings )
-// so what the APIs do is make you set all of this up ahead of time 
-// if you want to render something else you just bind that piece in there and you are good to go
-// otherwise you would have to pass in all that state over again, which wouldn't be great especially if the only thing you change is the textures you use
-// make them immutable might be a good idea as well, you can't reallocate a texture with a new size/format or whatever, you need to recreate it 
-// this would make debugging a lot easier
-
 
 Swapchain :: struct {
 

--- a/Windows-Platform-Layer.jai
+++ b/Windows-Platform-Layer.jai
@@ -1,28 +1,98 @@
 #scope_export
 
-init_window_class :: ( window_class: *Win32.WNDCLASSEXW, class_name: string, window_callback: win32_window_callback ) {
-	
-	window_class.cbSize 	   = size_of(Win32.WNDCLASSEXW);
-	window_class.lpszClassName = Windows_Utf8.utf8_to_wide( class_name ); 
-	window_class.hInstance     = Win32.GetModuleHandleW( null );
-	window_class.style 		   = Win32.CS_HREDRAW | Win32.CS_VREDRAW | Win32.CS_OWNDC;
-	window_class.lpfnWndProc   = cast(*void)window_callback;
-	window_class.hCursor       = Win32.LoadCursorW( null, Win32.IDC_ARROW );
+// Presentation of rendered images is tied to the window system used by the application.
+// Keyboard input is tied to the operating system as well.
+// Thus Image/Framebuffer and User Input types are added to this file.
 
-	window_class_registered := Win32.RegisterClassExW( window_class );
-	if !window_class_registered {
-		Basic.log_error( "Unable to register window class with name %, no windows can be created using this class\n", class_name );
-		Basic.exit( -1 );
-	}
-
-	return;
+Pixel :: struct {
+	// assumes simple RGBA format where each value is a byte
+	blue, green, red, alpha: u8;
 }
 
-init_window :: ( window: *Win32.HWND, class: Win32.WNDCLASSEXW, title: string, width: s32, height: s32, user_data: *void ) {
-	
-	window = Win32.CreateWindowExW( 
+// it's almost like using toggles
+// so in the D3D way you would have something like the object passed in and you set that state
+// i think this is what I am getting hung up on is how do you talk back and forth between these things
+
+// what Nicol is saying is that you could have a 'render-command' and that is what i am trying to do 
+// but then you have all these disparate object all over the place
+// the rendering call would literally look something like
+// render :: ( Shader1, shader2, texture1, texture2, texture..n, vertex data, framebuffer, viewport setting and blend settings )
+// so what the APIs do is make you set all of this up ahead of time 
+// if you want to render something else you just bind that piece in there and you are good to go
+// otherwise you would have to pass in all that state over again, which wouldn't be great especially if the only thing you change is the textures you use
+// make them immutable might be a good idea as well, you can't reallocate a texture with a new size/format or whatever, you need to recreate it 
+// this would make debugging a lot easier
+
+
+Swapchain :: struct {
+
+	NUMBER_OF_FRAMEBUFFERS :: 2;
+
+	framebuffers: [Swapchain.NUMBER_OF_FRAMEBUFFERS] [] Pixel;
+	image_format:  Win32.BITMAPINFO;
+
+	render_\target_index: int;
+	present_target_index: int;
+}
+
+Render_State :: struct {
+	// this is the active state used for draw/render and presentation calls
+	viewport: 	    *void;
+	render_target:  *void;
+	present_target: *void;
+	depth_buffer:   *void;
+	stencil_buffer: *void;
+	vertex_buffer:  *void;
+	index_buffer:   *void;
+}
+
+Render_Context :: struct {
+
+	device_context: Win32.HDC;   // required for 'paint' operations 
+	window:	    	Win32.HWND;	 // render context is associated 1:1 to the main application window
+	swapchain: 		Swapchain;
+	state:     		Render_State;
+}
+
+/*
+
+	State fields
+	render_context.resources.framebuffers[i];
+
+	render_context.state.viewport() 
+	render_context.state.render_target()
+	render_context.state.present_target()
+	render_context.state.vertex_buffer()
+	render_context.state.index_buffer()
+
+	Setting the State fields
+	render_context_bind_vertex_buffer();
+	render_context_bind_index_buffer();
+	render_context_bind_viewport()
+
+*/
+
+create_window :: ( title: string, width: s32, height: s32, callback: win32_window_callback ) -> (success: bool, Win32.HWND) {
+
+	// create the window class with sensible defaults 
+	window_class: Win32.WNDCLASSEXW;
+	window_class.cbSize 	   = size_of(Win32.WNDCLASSEXW);
+	window_class.lpszClassName = Windows_Utf8.utf8_to_wide( "App-Window-Class" ); 
+	window_class.hInstance     = Win32.GetModuleHandleW( null );
+	window_class.style 		   = Win32.CS_HREDRAW | Win32.CS_VREDRAW | Win32.CS_OWNDC;
+	window_class.lpfnWndProc   = cast(*void)callback;
+	window_class.hCursor       = Win32.LoadCursorW( null, Win32.IDC_ARROW );
+
+	// register the window class 	
+	registered_window_class := Win32.RegisterClassExW( *window_class );
+	if !registered_window_class {
+		Basic.log_error( "Unable to register window class, no windows can be created using this class.\n" );
+		return false, null;
+	}
+
+	window := Win32.CreateWindowExW( 
 		 0
-		,class.lpszClassName
+		,window_class.lpszClassName
 		,Windows_Utf8.utf8_to_wide( title )
 		,Win32.WS_OVERLAPPEDWINDOW | Win32.WS_CAPTION | Win32.WS_VISIBLE
 		,0, 0
@@ -30,19 +100,126 @@ init_window :: ( window: *Win32.HWND, class: Win32.WNDCLASSEXW, title: string, w
 		,null
 		,null
 		,Win32.GetModuleHandleW( null )
-		,user_data
+		,null
 	);
 
 	if !window {
-		Basic.log_error( "Unable to create a new window named % with window class %\n", title, class );
-		Basic.exit( -1 );
+		Basic.log_error( "Unable to create a new window named % with window class %\n", title, window_class.lpszClassName );
+		return false, null;
 	}
+
+	return true, window;
+}
+
+init_render_context :: ( render_context: *Render_Context, window: Win32.HWND ) {
+
+	render_context.device_context = Win32.GetDC( window );
+	render_context.window         = window;
+	render_context.swapchain      = create_swapchain( render_context, window );
+	
+	create_swapchain :: ( render_context: *Render_Context, window: Win32.HWND ) -> Swapchain {
+		
+		swapchain: Swapchain;
+		swapchain.render_target_index  = 0;
+		swapchain.present_target_index = 0;	
+
+		// allocate framebuffer memory matching the width and height of the PRIMARY MONITOR, not the WINDOW's extents
+		// code does not resize the framebuffers during runtime and does not handle multiple monitor scenarios
+		// if a window is resized the bitmap's width and height metadata are adjusted but memory is not reallocated
+		{
+			// Raymond Chen's blog post about finding primary monitor: https://devblogs.microsoft.com/oldnewthing/20070809-00/?p=25643
+			point_zero: Win32.POINT = .{ x = 0, y = 0 };
+			monitor := Win32.MonitorFromPoint( point_zero, Win32.MONITOR_DEFAULTTOPRIMARY );
+
+			info := Win32.MONITORINFOEX.{ cbSize = size_of(Win32.MONITORINFOEX) };
+			Win32.GetMonitorInfoA( monitor, cast(*Win32.MONITORINFO)*info );
+
+			monitor_width  := info.rcMonitor.right  - info.rcMonitor.left;
+			monitor_height := info.rcMonitor.bottom - info.rcMonitor.top;
+
+			for i: 0..Swapchain.NUMBER_OF_FRAMEBUFFERS-1 {
+				swapchain.framebuffers[i].data = Basic.alloc( monitor_width * monitor_height * size_of(Pixel) );
+				if !swapchain.framebuffers[i].data {
+					Basic.log_error( "Unable to allocate space for the image/frame buffers matching the monitor's dimensions (width,height) == (%,%)\n", monitor_width, monitor_height );
+				}
+				swapchain.framebuffers[i].count = monitor_width * monitor_height;
+			}
+		}
+
+		// initialize the 'BITMAPINFO' structure which defines the format of the data in the framebuffers/images
+		// Bitmap width and height match the client area of the window, not the initial requested window size 
+		{
+			client_area: Win32.RECT;
+			Win32.GetClientRect( window, *client_area );
+		
+			window_width  := client_area.right  - client_area.left;
+			window_height := client_area.bottom - client_area.top;
+
+			swapchain.image_format.bmiHeader.biSize     	= size_of(type_of(swapchain.image_format.bmiHeader));
+			swapchain.image_format.bmiHeader.biWidth        =  window_width;
+			swapchain.image_format.bmiHeader.biHeight		= -window_height; // top-down 'device-independent-bitmap' (DIB)
+			swapchain.image_format.bmiHeader.biPlanes   	= 1;
+			swapchain.image_format.bmiHeader.biBitCount 	= 32;
+			swapchain.image_format.bmiHeader.biCompression  = Win32.BI_RGB;
+		}
+
+		return swapchain;
+	}
+
+	Win32.SetWindowLongPtrW( window, Win32.GWLP_USERDATA, cast(Win32.LONG_PTR)render_context );
 
 	return;
 }
 
-window_callback :: ( window: Win32.HWND, message: u32, w_param: Win32.WPARAM, l_param: Win32.LPARAM ) -> Win32.LRESULT #c_call {
+resize_framebuffers :: ( render_context: *Render_Context ) {
 
+	// Memory for the framebuffers/images is set to a fixed-size (max of the primary display during window creation).
+	// When the window is resized, we update the bitmap header's width and height to match the new client area of the window.
+	//
+	// This prevents constantly resizing the framebuffer/image on window resizes; allocate it once then don't worry about it
+	//
+	// If a window is not full-screen then we are wasting memory but it is a choice, may need revised later.
+
+	client_area: Win32.RECT;
+	Win32.GetClientRect( render_context.window, *client_area );
+
+	width  := client_area.right  - client_area.left;
+	height := client_area.bottom - client_area.top;
+
+	render_context.swapchain.image_format.bmiHeader.biWidth  =  width;
+	render_context.swapchain.image_format.bmiHeader.biHeight = -height; // top-down DIB
+	
+	return;
+}
+
+draw_solid_color :: ( render_context: *Render_Context ) {
+
+	width  := render_context.swapchain.image_format.bmiHeader.biWidth;
+	height := render_context.swapchain.image_format.bmiHeader.biHeight * -1;
+
+	render_target_index := render_context.swapchain.render_target_index;
+	image               := render_context.swapchain.framebuffers[render_target_index];
+
+	pixel: *Pixel;
+	for y: 0..height-1 {
+	for x: 0..width-1 {
+		pixel = *(image[(y*width)+x]);
+		pixel.red 	=   255;
+		pixel.green =   0;
+		pixel.blue  = 	0;
+	}
+	}
+}
+	
+display_frame :: inline ( render_context: Render_Context ) {
+	
+	// trigger WM_PAINT message to be scheduled and handled; actual presentation done in the message handler
+	Win32.InvalidateRect( render_context.window, null, Win32.BOOL.FALSE );
+	Win32.UpdateWindow( render_context.window );
+}
+
+	
+window_callback :: ( window: Win32.HWND, message: u32, w_param: Win32.WPARAM, l_param: Win32.LPARAM ) -> Win32.LRESULT #c_call {
 
 	result: Win32.LRESULT = 0;
 
@@ -56,11 +233,24 @@ window_callback :: ( window: Win32.HWND, message: u32, w_param: Win32.WPARAM, l_
 	push_context new_context {
 
 	if message == {
-		case Win32.WM_CLOSE; #through;
-		case Win32.WM_QUIT; {
+		case Win32.WM_SIZE; {
+			render_context := cast(*Render_Context)Win32.GetWindowLongPtrW( window, Win32.GWLP_USERDATA );
+			if render_context {
+				// render context is initialized AFTER window creation and we could receive WM_SIZE messages before the context is initialized
+				// and set as the window data. Probably should refactor this
+				resize_framebuffers( render_context );
+			}
+		}
+		case Win32.WM_PAINT; {
+			render_context := cast(*Render_Context)Win32.GetWindowLongPtrW( window, Win32.GWLP_USERDATA );
+			present_frame( render_context );
+			swap_render_targets( render_context );
+		}
+		case Win32.WM_CLOSE; {
 			Win32.DestroyWindow( window );
-			Basic.exit (-1); // for now
-			// keep_window_open = false; // this needs to be accessible from the other function or through the window data
+		}
+		case Win32.WM_DESTROY; {
+			Win32.PostQuitMessage(0);
 		}
 		case; {
 			result = Win32.DefWindowProcW( window, message, w_param, l_param );
@@ -72,8 +262,6 @@ window_callback :: ( window: Win32.HWND, message: u32, w_param: Win32.WPARAM, l_
 	return result;
 }
 
-
-
 #scope_file
 
 Basic        :: #import "Basic";
@@ -81,3 +269,47 @@ Windows_Utf8 :: #import "Windows_Utf8";
 Win32 		 :: #import, file "Windows-Win32-Api.jai";
 
 win32_window_callback :: #type (Win32.HWND, u32, Win32.WPARAM, Win32.LPARAM ) -> Win32.LRESULT #c_call;
+
+present_frame :: ( render_context: *Render_Context ) {
+
+	present_target_index := render_context.swapchain.present_target_index;
+	image  				 := render_context.swapchain.framebuffers[present_target_index];
+
+	width  := cast(u32)render_context.swapchain.image_format.bmiHeader.biWidth;
+	height := cast(u32)(render_context.swapchain.image_format.bmiHeader.biHeight * -1);
+	
+	bitmap_info := *render_context.swapchain.image_format;
+
+	paint: Win32.PAINTSTRUCT;
+	Win32.BeginPaint( render_context.window, *paint );
+	scanlines := Win32.SetDIBitsToDevice(
+		render_context.device_context
+	   ,0,0,width,height
+	   ,0,0
+	   ,0
+	   ,height
+	   ,image.data
+	   ,bitmap_info
+	   ,Win32.DIBColors.DIB_RGB_COLORS
+	);
+
+	Win32.EndPaint( render_context.window, *paint );	
+
+	return;
+}
+
+
+swap_render_targets :: ( render_context: *Render_Context ) {
+
+	// swap the framebuffers so that the current render target becomes the next image to be presented and
+	// the existing presentation buffer is used for the next frame's draw calls
+	// 
+	// this code assumes a double-buffered approach
+
+	render_context.swapchain.present_target_index =  render_context.swapchain.render_target_index;
+	render_context.swapchain.render_\target_index = (render_context.swapchain.render_target_index + 1) % Swapchain.NUMBER_OF_FRAMEBUFFERS;
+
+	return;
+
+}
+

--- a/Windows-Win32-Api.jai
+++ b/Windows-Win32-Api.jai
@@ -16,6 +16,23 @@ HICON     :: HANDLE;
 HBRUSH    :: HANDLE;
 HCURSOR   :: HANDLE;
 HMENU     :: HANDLE;
+HMONITOR  :: HANDLE;
+
+// on 32-bit platforms this is actually a signed 32-bit integer.
+LONG_PTR  :: s64;
+
+RECT :: struct {
+	left:   s32;
+	top:    s32; 
+	right:  s32;
+	bottom: s32;
+}
+
+BOOL :: enum s32 {
+	FALSE :: 0;
+	TRUE  :: 1;
+
+}
 
 // Dynamic link library API
 GetModuleHandleW :: (module_name: *u16) -> HANDLE #foreign kernel32;
@@ -262,15 +279,33 @@ PM_NOYIELD  :: 0x0002;
 PeekMessageW     :: (msg: *MSG, hwnd: HWND, wMsgFilterMin: u32, wMsgFilterMax: u32, wRemoveMsg: u32) -> s32 #foreign user32;
 DispatchMessageW :: (msg: *MSG) -> s32 #foreign user32;
 TranslateMessage :: (msg: *MSG) -> s32 #foreign user32;
+PostQuitMessage  :: (nExitcode: s64)   #foreign user32;
 
-RECT :: struct {
-	left, top, right, bottom: s32;
+CREATESTRUCTW :: struct {
+	lpCreateParams: *void;
+	hInstance: HINSTANCE;
+	hMenu: HMENU;    
+	hwndParent: HWND;        
+	cy:    s32;
+    cx:    s32;
+    y: 	   s32;
+    x: 	   s32;
+    style: s32;
+  	lpszName:  *u16;
+  	lpszClass: *u16;
+	dwExStyle:  u32;
 }
 
-BOOL :: enum s32 {
-	FALSE :: 0;
-	TRUE  :: 1;
-}
+// Window field offsets for GetWindowLongPtr()
+// some of these use GWL for the prefix while others use GWLP, not sure why.
+// https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowlongptrw
+GWL_EXSTYLE			:: -20;
+GWLP_HINSTANCE		::  -6;
+GWLP_HWNDPARENT		::  -8;
+GWLP_ID				:: -12;
+GWL_STYLE			:: -16;
+GWLP_USERDATA		:: -21;
+GWLP_WNDPROC		::  -4;
 
 // Window procedures
 CreateWindowExW :: (
@@ -288,10 +323,44 @@ CreateWindowExW :: (
 	,lpParam: *void
 ) -> HWND #foreign user32;
 
+GetDC :: ( hWnd: HWND ) -> HDC #foreign user32;
+
+SetWindowLongPtrW :: (hWnd: HWND, nIndex: s32, dwNewLong: LONG_PTR ) -> LONG_PTR #foreign user32;
+GetWindowLongPtrW :: (hWnd: HWND, nIndex: s32) -> LONG_PTR #foreign user32; 
+
 DefWindowProcW  :: (hWnd: HWND, Msg: u32, wParam: WPARAM, lParam: LPARAM) -> s64 #foreign user32;
+GetClientRect   :: (hWnd: HWND, lpRect: *RECT) -> BOOL #foreign user32; 
+
 InvalidateRect  :: (hWnd: HWND, lpRect: *RECT, erase: BOOL ) -> BOOL #foreign user32;
 UpdateWindow    :: (hwnd: HWND) -> s32  #foreign user32;
+
 DestroyWindow   :: (hWnd: HWND) -> BOOL #foreign user32;
+
+// Windows Monitor Detection
+MONITORINFO :: struct {
+	cbSize: 	u32;
+	rcMonitor:  RECT;
+	rcWork:     RECT;
+	dwFlags:    u32;
+}
+
+CCHDEVICENAME: u32: 32;
+MONITORINFOEX :: struct {
+	// this struct inherits from the MONITORINFO class above.
+	// not sure if this type definition will work!
+	cbSize: 	u32;
+	rcMonitor:  RECT;
+	rcWork:     RECT;
+	dwFlags:    u32;
+	szDevice:   [CCHDEVICENAME] u8;	
+}
+
+MONITOR_DEFAULTTONULL    :: 0x00000000;
+MONITOR_DEFAULTTOPRIMARY :: 0x00000001;
+MONITOR_DEFAULTTONEAREST :: 0x00000002;
+
+MonitorFromPoint :: ( pt: POINT, dwFlags: u32 ) -> HMONITOR #foreign user32;
+GetMonitorInfoA  :: ( hMonitor: HMONITOR, lpmi: *MONITORINFO ) -> BOOL #foreign user32;
 
 // Window Cursors:
 IDC_APPSTARTING :: cast(*void) 32650;
@@ -348,9 +417,63 @@ BITMAPINFO :: struct {
 	bmiColors: [1] RGBQUAD;
 }
 
+DIBColors :: enum u32 {
+
+	DIB_RGB_COLORS  :: 0x00;
+   	DIB_PAL_COLORS  :: 0x01;
+   	DIB_PAL_INDICES :: 0x02;
+}
+
+// GDI raster operation codes (rop)
+SRCCOPY :: 0xcc0020;
+
+StretchDIBits :: (
+   hdc:   	  	HDC
+  ,xDest: 	  	s64
+  ,yDest: 	  	s64
+  ,destWidth: 	s64
+  ,destHeight: 	s64
+  ,xSrc: 		s64
+  ,ySrc:        s64
+  ,srcWidth: 	s64
+  ,srcHeight:	s64
+  ,lpBits:		*void
+  ,lpbmi:		*BITMAPINFO
+  ,iUsage:		DIBColors
+  ,rop:			u32	
+) -> s64 #foreign gdi32;
+
+SetDIBitsToDevice :: (
+   hdc: 	  HDC
+  ,xDest: 	  s64
+  ,yDest: 	  s64
+  ,w:     	  u32
+  ,h:     	  u32
+  ,xSrc:  	  s64
+  ,ySrc:  	  s64
+  ,startScan: u32
+  ,cLines:    u32
+  ,lpvBits:   *void
+  ,lpbmi:     *BITMAPINFO
+  ,colorUse:  DIBColors
+) -> s64 #foreign gdi32;
+
+// Windows paint types and procedures
+PAINTSTRUCT :: struct {
+ 	hdc: 	  	HDC; 
+  	fErase:   	BOOL;
+  	rcPaint:  	RECT;
+  	fRestore: 	BOOL;
+  	fIncUpdate: BOOL;
+  	rgbReserved: [32] u8;
+}
+
+BeginPaint :: ( hWnd: HWND, lpPaint: *PAINTSTRUCT ) -> HDC  #foreign user32;
+EndPaint   :: ( hWnd: HWND, lpPaint: *PAINTSTRUCT ) -> BOOL #foreign user32;
+
 #scope_file
 
-gdi      :: #system_library "gdi32";
+gdi32    :: #system_library "gdi32";
 kernel32 :: #system_library "kernel32";
 user32   :: #system_library "user32";
 

--- a/main.jai
+++ b/main.jai
@@ -5,30 +5,32 @@ main :: () {
 	window_width:  s32 = 600;
 	window_height: s32 = 400;
 
-	num_frame_buffers: int = 2;
+	success, window := Windows.create_window( 
+		 title    = "App-Window"
+		,width    = window_width
+		,height   = window_height
+		,callback = Windows.window_callback
+	);
 
-	window_class: Win32.WNDCLASSEXW;
-	Windows.init_window_class( *window_class, "App-Window-Class", Windows.window_callback );
+	if !success {
+		Basic.log_error( "Unable to create window\n" );
+		return;
+	}
 
-/*
-	window_user_data: Window_User_Data;
-	Windows.init_window_user_data( num_frame_buffers, user_input );
-*/
+	render_context: Windows.Render_Context;
+	Windows.init_render_context( *render_context, window );
 
-	window: Win32.HWND;
-	Windows.init_window( *window, window_class, "App-Window", window_width, window_height, null );
-
-	keep_window_open := true; // add this to the user data!
-	while keep_window_open {
-		window_messages: Win32.MSG;
-		while Win32.PeekMessageW( *window_messages, window, 0, 0, Win32.PM_REMOVE ) {
+	window_messages: Win32.MSG;
+	while window_messages.message != Win32.WM_QUIT {
+		if Win32.PeekMessageW( *window_messages, null, 0, 0, Win32.PM_REMOVE ) {
 			Win32.TranslateMessage( *window_messages );
-			Win32.DispatchMessageW(  *window_messages );
-
-			// update program state in here
-			// render into the frame buffer
+			Win32.DispatchMessageW( *window_messages );	
 		}
-	}	
+
+		Windows.draw_solid_color( *render_context ); 
+
+		Windows.display_frame( render_context );
+	}
 }
 
 #scope_file


### PR DESCRIPTION
Added Render_Context data structure to encapsulate the window, device and the renderer. Associate the render context to the window using the window user data slot on the Win32 Window data type